### PR TITLE
Show help when ctw is run with no arguments

### DIFF
--- a/ctw/main.py
+++ b/ctw/main.py
@@ -16,7 +16,7 @@ from ctw.providers.github import GitHubProvider
 from ctw.providers.linear import LinearProvider
 from ctw.settings import CONFIG_PATH, CtwSettings, _list_profiles, get_settings
 
-app = typer.Typer(help="claude-ticket-wrangler: Linear + GitHub Issues + wt integration")
+app = typer.Typer(help="claude-ticket-wrangler: Linear + GitHub Issues + wt integration", no_args_is_help=True)
 
 TrackerOpt = Annotated[
     str | None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,14 @@ def _mock_provider(issue: Issue | None = None) -> MagicMock:
     return provider
 
 
+class TestNoArgs:
+    def test_shows_help_not_error(self) -> None:
+        result = runner.invoke(app, [])
+        # no_args_is_help=True: CliRunner exits 2 (known Typer quirk) but shows help
+        assert "Missing command" not in result.output
+        assert "Commands" in result.output
+
+
 class TestListIssues:
     def test_renders_table(self) -> None:
         with patch("ctw.main.get_provider", return_value=_mock_provider()):


### PR DESCRIPTION
Add no_args_is_help=True to the Typer app so running ctw bare displays the command listing instead of a "Missing command." error.

Closes quickvm/ctw#1